### PR TITLE
fix(spa): don't throw when wwwroot/index.html is absent

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -302,10 +302,17 @@ app.Run();
 static Task ServeSpaIndex(HttpContext context, int statusCode) {
     context.Response.StatusCode = statusCode;
     context.Response.ContentType = "text/html; charset=utf-8";
-    return context.Response.SendFileAsync(Path.Combine(
+
+    var indexPath = Path.Combine(
         context.RequestServices.GetRequiredService<IHostEnvironment>().ContentRootPath,
         "wwwroot",
-        "index.html"));
+        "index.html");
+
+    // The frontend may not be built (backend tests / CI) — return the status and
+    // content-type without the SPA shell rather than throwing on a missing file.
+    return File.Exists(indexPath)
+        ? context.Response.SendFileAsync(indexPath)
+        : Task.CompletedTask;
 }
 
 // Exposed so integration tests can boot the real app via


### PR DESCRIPTION
ServeSpaIndex now sets the status + text/html content-type and only streams index.html when it exists, so the SPA-fallback integration tests pass in the backend CI job (frontend not built) and a missing build can't 500 the fallback.